### PR TITLE
Add SPF and DKIM for lists domain

### DIFF
--- a/opennicproject.org.yaml
+++ b/opennicproject.org.yaml
@@ -33,7 +33,11 @@ lists:
     preference: 0
 - type: TXT
   values:
-    - "v=spf1 include:_spf.opennic.org ip4:116.202.108.147 ip6:2a01:4f8:c014:c651::1 ~all" 
+    - "v=spf1 include:_spf.opennic.org ip4:116.202.108.147 ip6:2a01:4f8:c014:c651::1 ~all"
+sympa._domainkey.lists:
+- type: TXT
+  values:
+    - "v=DKIM1; h=sha256; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCZHHozd6qbI+xYteysE148xV5FM+WJUz6wmWeCRhLf21lP9qkgjhGBj+ClOjhhVqFYuw8pEngBGKS6QBaHUoH4IZgPVXdhGkMMrmnj0gi5o5hbuhQtPo/d0cRRB6PdztGT7+L8TMU3y0H0XMISA+oEucWjrQ6AfufGC3kuBD0kWwIDAQAB"
 members:
   type: CNAME
   value: members.opennic.org.

--- a/opennicproject.org.yaml
+++ b/opennicproject.org.yaml
@@ -31,6 +31,9 @@ lists:
   value:
     exchange: lists.darkdna.net.
     preference: 0
+- type: TXT
+  values:
+    - "v=spf1 include:_spf.opennic.org ip4:116.202.108.147 ip6:2a01:4f8:c014:c651::1 ~all" 
 members:
   type: CNAME
   value: members.opennic.org.


### PR DESCRIPTION
This adds an SPF record for the lists.opennicproject.org domain, which ideally will help with delivery issues. 